### PR TITLE
Include dist folder in repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Node dependencies
+node_modules/
+
+# Compiled output
+/out-tsc/
+
+# Coverage directory
+/coverage/
+
+# IDE files
+.vscode/
+.idea/
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# OS specific
+.DS_Store
+
+# Environment files
+.env
+

--- a/dist/README.md
+++ b/dist/README.md
@@ -1,0 +1,1 @@
+Built Angular distribution would go here.


### PR DESCRIPTION
## Summary
- keep dist folder under version control by removing it from `.gitignore`
- add placeholder `dist/README.md` to demonstrate the directory

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_6846095a7cb48333b5b0028da5924b9f