### PR TITLE
Fix tests for Angular 19 standalone components

### DIFF
--- a/src/app/about/about.component.spec.ts
+++ b/src/app/about/about.component.spec.ts
@@ -7,7 +7,7 @@ describe('AboutComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [AboutComponent]
+      imports: [AboutComponent]
     }).compileComponents();
 
     fixture = TestBed.createComponent(AboutComponent);

--- a/src/app/about/about.component.ts
+++ b/src/app/about/about.component.ts
@@ -1,7 +1,10 @@
 import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-about',
+  standalone: true,
+  imports: [CommonModule],
   templateUrl: './about.component.html'
 })
 export class AboutComponent { }

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -5,8 +5,7 @@ import { AppComponent } from './app.component';
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
-      declarations: [AppComponent]
+      imports: [RouterTestingModule, AppComponent]
     }).compileComponents();
   });
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,7 +1,10 @@
 import { Component } from '@angular/core';
+import { RouterModule } from '@angular/router';
 
 @Component({
   selector: 'app-root',
+  standalone: true,
+  imports: [RouterModule],
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css']
 })

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -22,7 +22,9 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  declarations: [
+  imports: [
+    BrowserModule,
+    RouterModule.forRoot(routes),
     AppComponent,
     HomeComponent,
     TeamsComponent,
@@ -32,7 +34,6 @@ const routes: Routes = [
     ChampionsComponent,
     AboutComponent
   ],
-  imports: [BrowserModule, RouterModule.forRoot(routes)],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/src/app/calendar/calendar.component.spec.ts
+++ b/src/app/calendar/calendar.component.spec.ts
@@ -7,7 +7,7 @@ describe('CalendarComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [CalendarComponent]
+      imports: [CalendarComponent]
     }).compileComponents();
 
     fixture = TestBed.createComponent(CalendarComponent);

--- a/src/app/calendar/calendar.component.ts
+++ b/src/app/calendar/calendar.component.ts
@@ -1,7 +1,10 @@
 import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-calendar',
+  standalone: true,
+  imports: [CommonModule],
   templateUrl: './calendar.component.html'
 })
 export class CalendarComponent { }

--- a/src/app/champions/champions.component.spec.ts
+++ b/src/app/champions/champions.component.spec.ts
@@ -7,7 +7,7 @@ describe('ChampionsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ChampionsComponent]
+      imports: [ChampionsComponent]
     }).compileComponents();
 
     fixture = TestBed.createComponent(ChampionsComponent);

--- a/src/app/champions/champions.component.ts
+++ b/src/app/champions/champions.component.ts
@@ -1,7 +1,10 @@
 import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-champions',
+  standalone: true,
+  imports: [CommonModule],
   templateUrl: './champions.component.html'
 })
 export class ChampionsComponent { }

--- a/src/app/competitions/competitions.component.spec.ts
+++ b/src/app/competitions/competitions.component.spec.ts
@@ -7,7 +7,7 @@ describe('CompetitionsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [CompetitionsComponent]
+      imports: [CompetitionsComponent]
     }).compileComponents();
 
     fixture = TestBed.createComponent(CompetitionsComponent);

--- a/src/app/competitions/competitions.component.ts
+++ b/src/app/competitions/competitions.component.ts
@@ -1,7 +1,10 @@
 import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-competitions',
+  standalone: true,
+  imports: [CommonModule],
   templateUrl: './competitions.component.html'
 })
 export class CompetitionsComponent { }

--- a/src/app/home/home.component.spec.ts
+++ b/src/app/home/home.component.spec.ts
@@ -7,7 +7,7 @@ describe('HomeComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [HomeComponent]
+      imports: [HomeComponent]
     }).compileComponents();
 
     fixture = TestBed.createComponent(HomeComponent);

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,7 +1,10 @@
 import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-home',
+  standalone: true,
+  imports: [CommonModule],
   templateUrl: './home.component.html'
 })
 export class HomeComponent { }

--- a/src/app/ranking/ranking.component.spec.ts
+++ b/src/app/ranking/ranking.component.spec.ts
@@ -7,7 +7,7 @@ describe('RankingComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [RankingComponent]
+      imports: [RankingComponent]
     }).compileComponents();
 
     fixture = TestBed.createComponent(RankingComponent);

--- a/src/app/ranking/ranking.component.ts
+++ b/src/app/ranking/ranking.component.ts
@@ -1,7 +1,10 @@
 import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-ranking',
+  standalone: true,
+  imports: [CommonModule],
   templateUrl: './ranking.component.html'
 })
 export class RankingComponent { }

--- a/src/app/teams/teams.component.spec.ts
+++ b/src/app/teams/teams.component.spec.ts
@@ -7,7 +7,7 @@ describe('TeamsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [TeamsComponent]
+      imports: [TeamsComponent]
     }).compileComponents();
 
     fixture = TestBed.createComponent(TeamsComponent);

--- a/src/app/teams/teams.component.ts
+++ b/src/app/teams/teams.component.ts
@@ -1,7 +1,10 @@
 import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-teams',
+  standalone: true,
+  imports: [CommonModule],
   templateUrl: './teams.component.html'
 })
 export class TeamsComponent { }


### PR DESCRIPTION
## Summary
- convert all components to standalone
- import standalone components in `AppModule`
- fix unit tests to use the `imports` array

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_b_68461b69919883338615c1a67710d33e